### PR TITLE
GH-26 Update to OpenTelemetry java agent version 1.29

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Now run `build-and-test.sh`. This will build the agent and the service, run the 
 Since the configuration service is not started when it's being instrumented, obtaining the remote configuration will fail and defaults will be used. You will see something like this in the log:
 
 ```
-opentelemetry-javaagent - version: 1.27.0-SNAPSHOT
+opentelemetry-javaagent - version: 1.29.0
 Could not connect to OTEL Configuration Service at http://localhost:8080,
 using sampler "parentbased_always_off".
 ```

--- a/extension/build.gradle
+++ b/extension/build.gradle
@@ -9,9 +9,8 @@ targetCompatibility = 11
 
 ext {
   versions = [
-    opentelemetrySdk           : "1.27.0",
-    opentelemetryJavaagent     : "1.27.0-SNAPSHOT",
-    opentelemetryJavaagentAlpha: "1.27.0-alpha-SNAPSHOT ",
+    opentelemetrySdk           : "1.29.0",
+    opentelemetryJavaagent     : "1.29.0",
   ]
   jarToPublish = file( 'build/libs/da-opentelemetry-javaagent.jar' )
   deps = [
@@ -42,7 +41,7 @@ publishing {
       maven(MavenPublication) {
           groupId = "no.domstolene"
           artifactId = "da-opentelemetry-javaagent"
-          version = "1.2.3"
+          version = "1.3.0"
           artifact jarToPublish
       }
   }

--- a/extension/src/test/java/no/domstol/otel/agent/configuration/AgentConfigurationTest.java
+++ b/extension/src/test/java/no/domstol/otel/agent/configuration/AgentConfigurationTest.java
@@ -30,7 +30,7 @@ public class AgentConfigurationTest {
     private String json =
             "{\n" +
             "  \"serviceName\" : \"da-otel-agent-service\",\n" +
-            "  \"sampler\" : \"parentbased_always_on\",\n" +
+            "  \"sampler\" : \"parentbased_always_off\",\n" +
             "  \"sampleRatio\" : 0.2,\n" +
             "  \"readOnly\" : false,\n" +
             "  \"timestamp\" : 0,\n" +

--- a/extension/src/test/resources/traces-configuration.yaml
+++ b/extension/src/test/resources/traces-configuration.yaml
@@ -1,5 +1,5 @@
 serviceName: da-otel-agent-service
-sampler: parentbased_always_on
+sampler: parentbased_always_off
 sampleRatio: 0.2
 readOnly: false
 rules:


### PR DESCRIPTION
* Fix the test rig so that it matches the documentation.
* Update version number to 1.3.0