### PR TITLE
Tag-triggered release workflow for immutable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,8 @@ on:
 # workflow builds.
 env:
   REGISTRY: ghcr.io
-  SERVICE_IMAGE_NAME:  domstolene/da-otel-agent-configuration-service
-  FRONTEND_IMAGE_NAME:  domstolene/da-otel-agent-configuration-frontend
+  SERVICE_IMAGE_NAME:  domstolene/da-otel-agent/configuration-service
+  FRONTEND_IMAGE_NAME:  domstolene/da-otel-agent/configuration-frontend
 
 jobs:
   build-test-and-publish-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,11 @@
 name: Build and publish release
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - '*.*.*'
 
-  workflow_dispatch:
-
-# Defines two custom environment variables for the workflow. These are used for 
+# Defines two custom environment variables for the workflow. These are used for
 # the Container registry domain, and a name for the Docker image that this
 # workflow builds.
 env:
@@ -15,17 +14,25 @@ env:
   FRONTEND_IMAGE_NAME:  domstolene/da-otel-agent-configuration-frontend
 
 jobs:
-  build-and-test-artifacts:  
+  build-test-and-publish-release:
 
-    name: Build and test artifacts
+    name: Build, test and publish release
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
 
     steps:
+    - name: Assert numeric version tag
+      run: |
+        version="${{ github.ref_name }}"
+        if ! echo "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+          echo "Invalid tag '$version'. Expected numeric format x.y.z"
+          exit 1
+        fi
+
     - uses: actions/checkout@v6
-    
+
     - name: Set up JDK 21
       uses: actions/setup-java@v5
       with:
@@ -39,36 +46,24 @@ jobs:
       run: ./gradlew build --no-daemon
 
     - name: Gradle publish agent
-      env: 
+      env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_ACTOR: ${{ github.actor }}
       run: ./gradlew publish --no-daemon
 
-    # Upload extension JAR for use in next job.
-    - uses: actions/upload-artifact@v6
-      with:
-        name: da-opentelemetry-javaagent.jar
-        path: extension/build/libs/da-opentelemetry-javaagent.jar
-        if-no-files-found: error
-
-    # Upload service JAR for use in next job.
-    - uses: actions/upload-artifact@v6
-      with:
-        name: service.jar
-        path: service/build/libs/service.jar
-        if-no-files-found: error
-
-    # Upload frontend JAR for use in next job.
-    - uses: actions/upload-artifact@v6
-      with:
-        name: frontend.jar
-        path: frontend/build/libs/frontend.jar
-        if-no-files-found: error
+    - name: Create release and upload agent JAR
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh release create "${{ github.ref_name }}" \
+          extension/build/libs/da-opentelemetry-javaagent.jar \
+          --repo "${{ github.repository }}" \
+          --generate-notes
 
   # Build and publish SERVICE container image.
   build-and-push-service-image:
     name: Build and push service image
-    needs: build-and-test-artifacts
+    needs: build-test-and-publish-release
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -83,28 +78,29 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-        
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.SERVICE_IMAGE_NAME }}
           tags: |
-            type=semver,pattern={{version}},value=${{ github.event.release.tag_name }},enable=${{ github.event_name == 'release' }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ github.event.release.tag_name }},enable=${{ github.event_name == 'release' }}
-            type=raw,value=${{ github.ref_name }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=semver,pattern={{version}},value=${{ github.ref_name }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ github.ref_name }}
           flavor: |
             latest=auto
 
-      - name: Download da-opentelemetry-javaagent.jar from previous job
-        uses: actions/download-artifact@v8
-        with:
-          name: da-opentelemetry-javaagent.jar
+      - name: Build service jar
+        run: ./gradlew :service:bootJar --no-daemon
 
-      - name: Download service.jar from previous job
-        uses: actions/download-artifact@v8
-        with:
-          name: service.jar
+      - name: Prepare service jar for Docker build context
+        run: cp service/build/libs/service.jar service.jar
+
+      - name: Download da-opentelemetry-javaagent.jar from release
+        run: |
+          curl -fLsS \
+            "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/da-opentelemetry-javaagent.jar" \
+            -o da-opentelemetry-javaagent.jar
 
       - name: Display structure of downloaded files
         run: ls -R
@@ -114,7 +110,7 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-        
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v7
         with:
@@ -128,7 +124,7 @@ jobs:
   # Build and publish FRONTEND container image.
   build-and-push-frontend-image:
     name: Build and push frontend image
-    needs: build-and-test-artifacts
+    needs: build-test-and-publish-release
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -143,28 +139,29 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-        
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }}
           tags: |
-            type=semver,pattern={{version}},value=${{ github.event.release.tag_name }},enable=${{ github.event_name == 'release' }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ github.event.release.tag_name }},enable=${{ github.event_name == 'release' }}
-            type=raw,value=${{ github.ref_name }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=semver,pattern={{version}},value=${{ github.ref_name }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ github.ref_name }}
           flavor: |
-            latest=auto            
+            latest=auto
 
-      - name: Download da-opentelemetry-javaagent.jar from previous job
-        uses: actions/download-artifact@v8
-        with:
-          name: da-opentelemetry-javaagent.jar
+      - name: Build frontend jar
+        run: ./gradlew :frontend:bootJar --no-daemon
 
-      - name: Download frontend.jar from previous job
-        uses: actions/download-artifact@v8
-        with:
-          name: frontend.jar
+      - name: Prepare frontend jar for Docker build context
+        run: cp frontend/build/libs/frontend.jar frontend.jar
+
+      - name: Download da-opentelemetry-javaagent.jar from release
+        run: |
+          curl -fLsS \
+            "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/da-opentelemetry-javaagent.jar" \
+            -o da-opentelemetry-javaagent.jar
 
       - name: Display structure of downloaded files
         run: ls -R
@@ -174,7 +171,7 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-        
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v7
         with:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # DA OpenTelemetry Agent & Service
 
-This project delivers an [OpenTelemetry Java Agent](https://opentelemetry.io/docs/instrumentation/java/automatic/) including a remotely configurable [sampler](https://opentelemetry.io/docs/concepts/sampling/), along with the accompanying REST service (and optional front-end) for configuring it. 
+This project delivers an [OpenTelemetry Java Agent](https://opentelemetry.io/docs/instrumentation/java/automatic/) including a remotely configurable [sampler](https://opentelemetry.io/docs/concepts/sampling/), along with the accompanying REST service (and optional front-end) for configuring it.
 
 ![](system.png)
 
@@ -85,7 +85,7 @@ In order to secure it (if need be), we suggest using an _oauth proxy_ in front o
 
 ## Usage
 
-There are basically three ways of configuring the agent. Either you use a file-based configuration, a service-based, or both. 
+There are basically three ways of configuring the agent. Either you use a file-based configuration, a service-based, or both.
 
 A typical use case would be to set up a file based configuration while pointing to the service. In this case the agent will load and use the configuration from the file. It will connect to the service, and if the the agent is not registered there, upload the current configuration. If the configuration is changed on the service, the agent will update and use this version, unless the `readOnly` flag is set to true. The configuration file will automatically be reloaded if changed.
 
@@ -166,3 +166,33 @@ Changing sampler to AlwaysOnSampler
 ```
 
 The `DynamicSamplerProvider` will poll the service at regular intervals (currently each 30s) to check for updated configurations. You should be able to see this in the Jaeger UI.
+
+## Releasing
+
+Releases are created from Git tags using the [release workflow](.github/workflows/release.yml). The workflow is compatible with GitHub immutable releases because it creates the release itself only after a successful build.
+
+Do not create releases manually in the GitHub UI.
+
+### Steps
+
+1. Make sure the `main` branch contains the version you want to release.
+2. Create an annotated version tag (for example `1.2.3`):
+
+```bash
+git checkout main
+git pull
+git tag -a 1.2.3 -m "Release 1.2.3"
+git push origin 1.2.3
+```
+
+3. Wait for the `Build and publish release` workflow to complete.
+
+When successful, the workflow will:
+
+1. Build and test the project.
+2. Publish the agent artifact and create a GitHub release with `da-opentelemetry-javaagent.jar` attached.
+3. Build and push service/frontend container images.
+
+Download URL format for released agent JAR:
+
+`https://github.com/domstolene/da-otel-agent/releases/download/<version>/da-opentelemetry-javaagent.jar`


### PR DESCRIPTION
## What changed

This PR updates the release flow so tagged releases are created by the workflow itself, which makes it compatible with GitHub immutable releases.

The full set of changes included here is:

- Upgraded the GitHub Actions used in the workflow to newer versions
- Changed the release trigger from manual release publishing to numeric x.y.z tag pushes
- Added validation that release tags are numeric only
- Created the GitHub release from the workflow with gh release create and attached da-opentelemetry-javaagent.jar
- Updated the Docker image names to use slash namespaces for clearer ownership and less manual registry setup
- Documented the new release process in the README

## Why

GitHub immutable releases do not allow the old pattern of uploading assets after a release already exists. Creating the release inside the workflow ensures the JAR is attached at publish time and keeps the flow repeatable and automated.