### PR TITLE
Oppdatering av CodeQL-workflow: bygging av kode og nyere actions, java21  

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,15 +39,15 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'java-kotlin' ]
-        
+ 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
 
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v5
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         
 #    - name: Set up Gradle
@@ -58,9 +58,10 @@ jobs:
         
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
+        build-mode: none  
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
@@ -70,10 +71,10 @@ jobs:
 
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+    #- name: Autobuild  
+    #  uses: github/codeql-action/autobuild@v4
       
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,6 +17,7 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main" ]
+  workflow_dispatch:
   schedule:
     - cron: '45 23 * * 3'
 
@@ -49,19 +50,16 @@ jobs:
       with:
         java-version: '21'
         distribution: 'temurin'
-        
-#    - name: Set up Gradle
-#      uses: gradle/actions/setup-gradle@v5
-#
-#    - name: Gradle build
-#      run: ./gradlew build --no-daemon -PGITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} -PGITHUB_USER=${{ github.actor }}
+    
+    - name: Set up Gradle
+      uses: gradle/actions/setup-gradle@v5
         
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
-        build-mode: none  
+        build-mode: manual
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
@@ -69,10 +67,8 @@ jobs:
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
-    # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    #- name: Autobuild  
-    #  uses: github/codeql-action/autobuild@v4
+    - name: Gradle build
+      run: ./gradlew build --no-daemon -PGITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} -PGITHUB_USER=${{ github.actor }}
       
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
Enkelte kjøringer av CodeQL i da-otel-agent produserte feil og warnings under kjøring.
Jeg kikket på dette og har gjort følgende:

- endret til nyere actions som var meldt som deprecated (@v3 => @v4)
- byggemodus var ikke satt eksplisitt, satt den til "none" (det var dette kom det noen feilmeldinger på i loggene)
- pga punktet over kommenterte jeg ut autobuild-steget

Jeg har også:
 
- oppdatert til JDK 21 (fra JDK 17) siden den versjonen er referert i release.yml og service.yml

OBS: Det er fremdeles en referanse til JDK 17 i ci.yml. 